### PR TITLE
don't try to SplitHostPort when the target garden is on a unix socket

### DIFF
--- a/commands/net_in.go
+++ b/commands/net_in.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"net"
+	"os"
 )
 
 type NetIn struct {
@@ -16,8 +17,13 @@ func (command *NetIn) Execute(maybeHandle []string) error {
 	hostPort, _, err := container.NetIn(0, uint32(command.Port))
 	failIf(err)
 
-	host, _, err := net.SplitHostPort(Globals.Target.Address)
-	failIf(err)
+	host := Globals.Target.Address
+	if _, err := os.Stat(host); err == nil {
+		host = "127.0.0.1"
+	} else {
+		host, _, err = net.SplitHostPort(host)
+		failIf(err)
+	}
 
 	fmt.Println(net.JoinHostPort(host, fmt.Sprintf("%d", hostPort)))
 


### PR DESCRIPTION
When `Globals.Target.Address` is a unix socket filepath, then `net.SplitHostPort` will error.
