### PR TITLE
Optional --image flag for run subcommand

### DIFF
--- a/commands/run.go
+++ b/commands/run.go
@@ -14,6 +14,7 @@ type Run struct {
 	User    string   `short:"u" long:"user" description:"user to run the process as" default:"root"`
 	Command string   `short:"c" long:"command" description:"command to run in container"`
 	Env     []string `short:"e" long:"env" description:"set environment variables"`
+	Image   string   `short:"i" long:"image" description:"Root filesystem for process"`
 }
 
 func (command *Run) Execute(maybeHandle []string) error {
@@ -36,11 +37,12 @@ func (command *Run) Execute(maybeHandle []string) error {
 	failIf(err)
 
 	process, err := container.Run(garden.ProcessSpec{
-		Path: args[0],
-		Args: args[1:],
-		Dir:  command.Dir,
-		User: command.User,
-		Env:  command.Env,
+		Path:  args[0],
+		Args:  args[1:],
+		Dir:   command.Dir,
+		User:  command.User,
+		Env:   command.Env,
+		Image: garden.ImageRef{URI: command.Image},
 	}, processIo)
 	failIf(err)
 


### PR DESCRIPTION
Garden can now run processes in a [different mount namespace than the rest of the container's processes](https://godoc.org/code.cloudfoundry.org/garden#ProcessSpec), and can therefore have its own root filesystem.

We've added an optional flag on the run subcommand to deal with this. If it's not set, the `garden.ImageRef` struct will be zero-valued and Garden will do what it always used to do with the process.

This feature is still experimental, and there are many restrictions on this sort of process. For example, they will not survive Garden server restarts, and they can't be run from privileged containers.