### PR TITLE
Optional bind mount mode

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -17,22 +17,28 @@ type Create struct {
 	Grace      time.Duration `short:"g" long:"grace" description:"grace time (resetting ttl) of container"`
 	Privileged bool          `short:"p" long:"privileged" description:"privileged user in the container is privileged in the host"`
 	Network    string        `long:"network" description:"the subnet of the container"`
-	BindMounts []string      `short:"m" long:"bind-mount" description:"bind mount host-path:container-path"`
+	BindMounts []string      `short:"m" long:"bind-mount" description:"bind mount host-path:container-path:optional-bind-mount-mode"`
 }
 
 func (command *Create) Execute(args []string) error {
 	var bindMounts []garden.BindMount
 
 	for _, pair := range command.BindMounts {
-		segs := strings.SplitN(pair, ":", 2)
-		if len(segs) != 2 {
-			fail(fmt.Errorf("invalid bind-mount segment (must be host-path:container-path): %s", pair))
+		segs := strings.SplitN(pair, ":", 3)
+		if len(segs) < 2 {
+			fail(fmt.Errorf("invalid bind-mount segment (must be host-path:container-path:optional-bind-mount-option): %s", pair))
+		}
+
+		var bindMountMode garden.BindMountMode
+		var err error
+		if bindMountMode, err = getBindMountMode(segs); err != nil {
+			fail(err)
 		}
 
 		bindMounts = append(bindMounts, garden.BindMount{
 			SrcPath: segs[0],
 			DstPath: segs[1],
-			Mode:    garden.BindMountModeRW,
+			Mode:    bindMountMode,
 			Origin:  garden.BindMountOriginHost,
 		})
 	}
@@ -52,4 +58,19 @@ func (command *Create) Execute(args []string) error {
 	fmt.Println(container.Handle())
 
 	return nil
+}
+
+func getBindMountMode(bindMountSegments []string) (garden.BindMountMode, error) {
+	if len(bindMountSegments) < 3 {
+		return garden.BindMountModeRW, nil
+	}
+
+	switch bindMountSegments[2] {
+	case "ro":
+		return garden.BindMountModeRO, nil
+	case "rw":
+		return garden.BindMountModeRW, nil
+	default:
+		return 0, fmt.Errorf("invalid bind mount mode (must be either 'rw' (read-write), or 'ro' (read-only))")
+	}
 }

--- a/test/create.bats
+++ b/test/create.bats
@@ -23,3 +23,38 @@ load test_helper
   assert_match $handle
 }
 
+@test "a created container bind mount is read-write by default" {
+  handle=$(gaol create -m .:/tmp/cmnt)
+  assert_success
+
+  run gaol run -a -c "/bin/sh -c 'cat /proc/self/mounts | grep /tmp/cmnt'" $handle
+
+  assert_success
+  assert_match " rw,"
+}
+
+@test "a created container can have read-only bind mounts" {
+  handle=$(gaol create -m .:/tmp/cmnt:ro)
+  assert_success
+
+  run gaol run -a -c "/bin/sh -c 'cat /proc/self/mounts | grep /tmp/cmnt'" $handle
+
+  assert_success
+  assert_match " ro,"
+}
+
+
+@test "a created container can have explicit read-write bind mounts" {
+  handle=$(gaol create -m .:/tmp/cmnt:rw)
+  assert_success
+
+  run gaol run -a -c "/bin/sh -c 'cat /proc/self/mounts | grep /tmp/cmnt'" $handle
+
+  assert_success
+  assert_match " rw,"
+}
+
+@test "creation fails if unsupported bind mount mode is provided" {
+  run gaol create -m .:/tmp/cmnt:foo
+  assert_failure
+}


### PR DESCRIPTION
There are only two bind mount modes supported:
* `rw` (read-write, default)
* `ro` (read-only)

One can create a read-only bind mount via
`gaol create -m hostpath:containerpath:ro`

If the bind mount mode is not specified, `rw` is assumed, therefore the
following two have the same effect:
`gaol create -m hostpath:containerpath`
`gaol create -m hostpath:containerpath:rw`